### PR TITLE
Use HTTPS instead of SSH GitHub URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mateodelnorte/meta-project.git"
+    "url": "https://github.com/mateodelnorte/meta-project.git"
   },
   "keywords": [
     "project",


### PR DESCRIPTION
Unable to install meta behind a corporate proxy due to SSH GitHub URL.