### PR TITLE
feat: autodetect <childRepoUrl> when importing existing <destFolder>

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ project plugin for [meta](https://github.com/mateodelnorte/meta)
 ## Usage
 
 ```
-  Usage: meta project [options] [command]
+  Usage: meta project [<options>] <command>
 
 
   Commands:
@@ -15,7 +15,7 @@ project plugin for [meta](https://github.com/mateodelnorte/meta)
     create      create and initialize a new child repository
     import      import an existing child repository via git clone
     migrate     migrate from a monorepo to a metarepo
-    help [cmd]  display help for [cmd]
+    help <cmd>  display help for <cmd>
 
   Options:
 
@@ -25,7 +25,7 @@ project plugin for [meta](https://github.com/mateodelnorte/meta)
 
 ## Creating a new project
 
-To create a new project, use `meta project create [folder] [repo url]`
+To create a new project, use `meta project create <folder> <repo url>`
 
 ```
 meta project create new-dir git@github.com/org/repo
@@ -71,8 +71,9 @@ meta project migrate project-c git@github.com/yourorg/project-c
 ```
 
 This will keep the git history of each subproject in tact, using some git magic:
-* Explanation: https://help.github.com/en/articles/splitting-a-subfolder-out-into-a-new-repository
-* Implementation: https://github.com/mateodelnorte/meta-project/blob/master/lib/splitSubtree.js
+
+- Explanation: https://help.github.com/en/articles/splitting-a-subfolder-out-into-a-new-repository
+- Implementation: https://github.com/mateodelnorte/meta-project/blob/master/lib/splitSubtree.js
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -33,16 +33,22 @@ meta project create new-dir git@github.com/org/repo
 
 ## Import an existing project
 
-To import an existing project, use `meta project import [folder] [repo url]`
+To import an existing project, use `meta project import <folder> [<repo url>]`
 
 ```
 meta project import projects/example git@github.com/your-org/example
 ```
 
+To import existing project which is already checked out at <folder>, <repo-url> can be omitted
+
+```
+meta project import projects/example
+```
+
 ## Migrate a Monorepo to a metarepo and keep your git history intact.
 
-'meta project migrate' helps you move from a monorepo to a meta repo by moving directories from 
-your existing repo into separate child repos, with git history intact. These are then referenced in 
+'meta project migrate' helps you move from a monorepo to a meta repo by moving directories from
+your existing repo into separate child repos, with git history intact. These are then referenced in
 your '.meta' file and cloned, making the operation transparent to your codebase.
 
 For example, given the following monorepo structure:
@@ -64,7 +70,7 @@ meta project migrate project-b git@github.com/yourorg/project-b
 meta project migrate project-c git@github.com/yourorg/project-c
 ```
 
-This will keep the git history of each subproject in tact, using some git magic: 
+This will keep the git history of each subproject in tact, using some git magic:
 * Explanation: https://help.github.com/en/articles/splitting-a-subfolder-out-into-a-new-repository
 * Implementation: https://github.com/mateodelnorte/meta-project/blob/master/lib/splitSubtree.js
 
@@ -84,10 +90,10 @@ now also has it's own distinct history.
 ## Migration Phase
 
 If you need the monorepos structure to stay in tact for any extended duration, such as supporting legacy CI
-systems, you can stop here. 
+systems, you can stop here.
 
-While in this 'migration' phase, you need to commit to the child directory's git history as well as the 
-monorepo's git history. These commits can literally be made twice by cd-ing around or both can be made 
+While in this 'migration' phase, you need to commit to the child directory's git history as well as the
+monorepo's git history. These commits can literally be made twice by cd-ing around or both can be made
 at once using 'meta git commit'.
 
 ## Finishing the Migration

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To import an existing project, use `meta project import <folder> [<repo url>]`
 meta project import projects/example git@github.com/your-org/example
 ```
 
-To import existing project which is already checked out at <folder>, <repo-url> can be omitted
+To import existing project which is already checked out at `<folder>`, `<repo-url>` can be omitted
 
 ```
 meta project import projects/example

--- a/bin/meta-project-import
+++ b/bin/meta-project-import
@@ -3,11 +3,18 @@
 const fs = require('fs');
 const tildify = require('tildify');
 const gitClone = require('../lib/gitClone');
+const getCurrentRepoRemote = require('../lib/getCurrentRepoRemote');
 
 const usage = () => {
-  console.log(`Usage: meta-project-import <destFolder> <childRepoUrl>
-  
-Configures .meta file and imports a project from provided 'childRepoUrl' using git clone into 'destFolder'.`);
+  console.log(`Usage: meta-project-import <destFolder> [<childRepoUrl>]
+
+Configures .meta file and imports a project from provided 'destFolder'.
+
+  'destFolder' exists:
+      no 'childRepoUrl' defined: the remote will be detected
+      'childRepoUrl' defined: the remote will be updated
+
+  'destFolder' does not exist: 'childRepoUrl' will be cloned into 'destFolder'.`);
   process.exit(1);
 };
 
@@ -18,9 +25,9 @@ const run = ({
   /^(-h||--help)$/.test(argv[2]) && usage();
   
   const destArg = argv[2] === 'blank' ? argv[3] : argv[2];
-  const repoUrl = argv[3] === 'blank' ? argv[4] : argv[3];
-  (destArg && repoUrl) || usage();
-  
+  let repoUrl = argv[3] === 'blank' ? argv[4] : argv[3];
+  destArg || usage();
+
   const path = require('path');
   const { green, gray, cyan, inverse } = require('chalk');
   const getMetaFile = require('get-meta-file');
@@ -43,9 +50,22 @@ const run = ({
   }
   
   const gitExists = destExists && fs.existsSync(path.join(dest, '.git'));
-  if (meta.projects[dest] === repoUrl && gitExists) {
-    console.log(`${green('✓')} A git repository already exists at this location. No changes required.`);
-    process.exit(0);
+  let detected = false;
+  if (gitExists) {
+    if (repoUrl && meta.projects[dest] === repoUrl) {
+      console.log(`${green('✓')} A git repository already exists at this location. No changes required.`);
+      process.exit(0);
+    } else if (!repoUrl) {
+      repoUrl = getCurrentRepoRemote({
+        cwd: dest
+      });
+      if (!repoUrl) {
+        console.log(`💥 '${dest}' exists but has no remote`);
+        process.exit(1);
+      } else {
+        detected = true;
+      }
+    }
   }
 
   const cb = err => {
@@ -61,8 +81,11 @@ const run = ({
     if (!meta.projects) meta.projects = {};
     meta.projects[dest] = repoUrl;
     getMetaFile.save(meta);
-  
-    console.log(`\n${green('✓')} Project ${destExists ? 'already exists. No changes required.' : 'imported'}: ${green(dest)}`); // prettier-ignore
+    if (detected) {
+      console.log(`\n${green('✓')} Project imported: ${green(dest)} (${green(repoUrl)})`); // prettier-ignore
+    } else {
+      console.log(`\n${green('✓')} Project ${destExists ? 'already exists. No changes required.' : 'imported'}: ${green(dest)}`); // prettier-ignore
+    }
   }
   
   gitClone({

--- a/bin/meta-project-migrate
+++ b/bin/meta-project-migrate
@@ -87,7 +87,10 @@ const run = ({
   }
 
   const rootRepo = getCurrentRepoRemote()
-
+  if (!rootRepo) {
+    console.log(`💥 no root repo found`);
+    process.exit(1);
+  }
   console.log(`Root remote found: ${cyan(tildify(rootRepo))}`)
 
   const monorepoDir = process.cwd()

--- a/lib/getCurrentRepoRemote.js
+++ b/lib/getCurrentRepoRemote.js
@@ -1,10 +1,22 @@
 const childProcess = require('child_process');
 
-function getCurrentRepoRemote() {
-  return childProcess
-    .execSync('git remote get-url origin')
-    .toString()
-    .trim();
+function getCurrentRepoRemote(options) {
+  let res;
+  try {
+    res = childProcess
+      .execSync(
+        'git remote get-url origin',
+        Object.assign(
+          {
+            stdio: ['ignore', 'pipe', 'ignore'],
+          },
+          options
+        )
+      )
+      .toString()
+      .trim();
+  } catch (err) {}
+  return res;
 }
 
 module.exports = getCurrentRepoRemote;


### PR DESCRIPTION
Added the possibility to omit the \<childRepoUrl\> when importing an existing \<destFolder\>.