### PR TITLE
Don't remove old origin after a git init

### DIFF
--- a/bin/meta-project-create
+++ b/bin/meta-project-create
@@ -70,7 +70,7 @@ gitInit((err) => {
 function gitInit(cb) {
   if (gitExists) {
     console.log(`Found pre-existing git repository`); // prettier-ignore
-    return gitSetup(cb);
+    return gitUpdateRemote(cb);
   }
   exec(
     {
@@ -79,12 +79,27 @@ function gitInit(cb) {
     },
     (err) => {
       if (err) cb(err);
-      else gitSetup(cb);
+      else gitAddRemote(cb);
     }
   );
 }
 
-function gitSetup(cb) {
+function gitAddRemote(cb) {
+  console.log(`Adding new origin to ${cyan(repoUrl)}`);
+  exec(
+    {
+      command: `git remote add origin ${repoUrl}`,
+      suppressLogging: true,
+      stdio: 'ignore',
+    },
+    (err) => {
+      if (err) return cb(err);
+      return cb();
+    }
+  );
+}
+
+function gitUpdateRemote(cb) {
   console.log(`Updating origin to ${cyan(repoUrl)}`);
   exec(
     {


### PR DESCRIPTION
Removing a non-existent remote causes an error, preventing the `add remote` code to be executed.

So I split the gitSetup method in two: an add method and an update method (remove+add).