### PR TITLE
migrate: switch to git-filter-repo, make temp dir creation more robust, enable changing default branch name

### DIFF
--- a/bin/meta-project-migrate
+++ b/bin/meta-project-migrate
@@ -58,7 +58,7 @@ const run = ({ process }) => {
 
   const destArg = argv[2] === 'blank' ? argv[3] : argv[2];
   const repoUrl = argv[3] === 'blank' ? argv[4] : argv[3];
-  const branch = argv[4] === 'blank' ? null : argv[4];
+  const branch = (argv[4] === 'blank' ? null : argv[4]) || "master";
   (destArg && repoUrl) || usage();
 
   // Load the ".meta" module.
@@ -93,29 +93,30 @@ const run = ({ process }) => {
   console.log(`Root remote found: ${cyan(tildify(rootRepo))}`);
 
   const monorepoDir = process.cwd();
-  const tempDir = path.resolve(monorepoDir, './.tmp');
-  console.log({ tempDir });
-  mkdirp.sync(tempDir);
+  const tempDir = fs.mkdtempSync("meta-project-migrate-");
+  console.log(tempDir);
 
   function afterGitClone(err) {
     if (err) throw err;
 
+    console.log(`Splitting subdirectory "${dest}" history into temporary folder "${tempDir}"`);
+    splitSubtree({
+      subdirectory: dest,
+      source: monorepoDir,
+      target: tempDir,
+      branch: branch,
+    });
+
     process.chdir(tempDir);
 
     console.log(`Now working in ${tempDir}`);
-
+    
     console.log(`Removing original remote "origin"`);
 
     removeRemote({
       remoteName: 'origin',
     });
-
-    console.log(`Splitting subdirectory "${dest}" history`);
-
-    splitSubtree({
-      subdirectory: dest,
-    });
-
+    
     console.log(`Setting remote origin to ${repoUrl}`);
 
     addRemote({
@@ -123,12 +124,11 @@ const run = ({ process }) => {
       gitUrl: repoUrl,
     });
 
-    let pushBranch = branch || 'master';
-    console.log(`Pushing split history to new remote origin ${repoUrl} on branch ${pushBranch}`);
+    console.log(`Pushing split history to new remote origin ${repoUrl} on branch ${branch}`);
 
     gitPush({
       remote: 'origin',
-      branch: pushBranch,
+      branch: branch,
     });
 
     process.chdir(monorepoDir);

--- a/bin/meta-project-migrate
+++ b/bin/meta-project-migrate
@@ -55,15 +55,15 @@ When the monorepo no longer needs to be maintained you can simply add it to your
 const run = ({ process }) => {
   const { argv } = process;
   /^(-h||--help)$/.test(argv[2]) && usage();
-
-  const destArg = argv[2] === 'blank' ? argv[3] : argv[2];
-  const repoUrl = argv[3] === 'blank' ? argv[4] : argv[3];
-  const branch = (argv[4] === 'blank' ? null : argv[4]) || "master";
-  (destArg && repoUrl) || usage();
-
+  
   // Load the ".meta" module.
   const meta = getMetaFile();
   if (!meta) process.exit(1);
+
+  const destArg = argv[2] === 'blank' ? argv[3] : argv[2];
+  const repoUrl = argv[3] === 'blank' ? argv[4] : argv[3];
+  const branch = (argv[4] === 'blank' ? null : argv[4]) || meta.defaultBranch || "master";
+  (destArg && repoUrl) || usage();
 
   const metaPath = getMetaFile.getFileLocation();
   const dest = path.relative(path.dirname(metaPath), path.resolve(destArg));

--- a/lib/splitSubtree.js
+++ b/lib/splitSubtree.js
@@ -1,8 +1,8 @@
 const childProcess = require('child_process');
 
-function splitSubtree({ subdirectory, branch = 'master' }) {
+function splitSubtree({ subdirectory, source, target, branch }) {
   return childProcess
-    .execSync(`git filter-branch --prune-empty --subdirectory-filter ${subdirectory} ${branch}`)
+    .execSync(`git filter-repo --subdirectory-filter ${subdirectory} --refs ${branch} --source ${source} --target ${target}`)
     .toString()
     .trim();
 }


### PR DESCRIPTION
Hey there, I'm currently using `meta` to restructure a monorepo I work on, and I've made these changes to `meta-project-migrate`:

- switch to `git filter-repo` instead of `git filter-branch` because it's been deprecated https://git-scm.com/docs/git-filter-branch#_warning (requires separate install)
- use Node's `mkdtempSync` function to get a temp folder in `/usr/tmp` instead of making one inside the repo - `filter-repo` won't work otherwise
- pass the branch argument to `splitSubtree` so that we can use `main` instead of `master` https://github.com/mateodelnorte/meta/issues/281
- read the value of `defaultBranch` if available so that `main` can be set on a project level

I'm not finished migrating the repo yet - I need to make some more changes to make other meta commands read the `defaultBranch` option. I've opened this PR now for early feedback since I'm not sure how you would like to review these changes, or if you'd like to accept them all, so let me know and I can split up this PR if needed.
