### PR TITLE
fix: if only repo url is provided, show usage

### DIFF
--- a/bin/meta-project-import
+++ b/bin/meta-project-import
@@ -64,6 +64,8 @@ const run = ({ process }) => {
         detected = true;
       }
     }
+  } else if (!destExists && !repoUrl) {
+    usage();
   }
 
   const cb = (err) => {


### PR DESCRIPTION
Prevent adding git URL to `.gitignore` if only the git URL is provided as cli param.

fixes: #104 