### PR TITLE
Update meta-project-migrate to pass "branch" to splitSubtree()

### DIFF
--- a/bin/meta-project-migrate
+++ b/bin/meta-project-migrate
@@ -114,6 +114,7 @@ const run = ({ process }) => {
 
     splitSubtree({
       subdirectory: dest,
+      branch
     });
 
     console.log(`Setting remote origin to ${repoUrl}`);


### PR DESCRIPTION
It seems that splitSubtree() was set up to accept a "branch" parameter, with a default value set to "master"; and the meta-project-migrate script already seems to accept a final command-line argument for "branch" (which isn't documented btw), HOWEVER, the script doesn't actually pass the user-specified "branch" through to splitSubtree() -- so if your main branch isn't called "master" (like mine), the migrate script doesn't work. This PR adds a single-line fix, although untested.